### PR TITLE
chip 공통 컴포넌트 구현 (issue #13)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@tanstack/react-query": "^5.90.2",
-
         "@types/react-datepicker": "^7.0.0",
         "@use-funnel/react-router": "^0.0.5",
         "@use-funnel/react-router-dom": "^0.0.14",
@@ -47,6 +46,9 @@
         "webpack": "^5.102.0",
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.2"
+      },
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/src/components/common/chip/chip.styles.ts
+++ b/src/components/common/chip/chip.styles.ts
@@ -1,0 +1,120 @@
+import styled from '@emotion/styled';
+import { colors } from '../../../style/colors';
+import { typography } from '../../../style/theme';
+
+export type ChipVariant = 'default' | 'primary' | 'outlined' | 'defaultOutlined';
+export type ChipSize = 'small' | 'medium' | 'large';
+
+interface ChipButtonProps {
+  $variant: ChipVariant;
+  $size: ChipSize;
+  $isActive: boolean;
+}
+
+const getChipStyles = ($variant: ChipVariant, $isActive: boolean) => {
+  // primary: 항상 초록 배경, 테두리 없음
+  if ($variant === 'primary') {
+    return {
+      background: colors.green[200],
+      color: colors.gray[900],
+      border: 'none',
+    };
+  }
+
+  // outlined: isActive에 따라 색상 변경, 테두리는 항상 유지
+  if ($variant === 'outlined') {
+    return {
+      background: colors.gray[100],
+      color: colors.gray[700],
+      border: `1px solid ${colors.gray[500]}`,
+    };
+  }
+
+  // defaultOutlined: 회색 배경에 테두리 (isActive 무시)
+  if ($variant === 'defaultOutlined') {
+    if ($isActive) {
+      return {
+        background: colors.gray[100],
+        color: colors.gray[700],
+        border: `1px solid ${colors.gray[500]}`,
+      };
+    }
+    return {
+      background: colors.gray[100],
+      color: colors.gray[700],
+      border: 'none',
+    };
+  }
+
+  // default: isActive에 따라 색상 변경, 테두리 없음
+  if ($isActive) {
+    return {
+      background: colors.green[200],
+      color: colors.gray[900],
+      border: 'none',
+    };
+  }
+
+  return {
+    background: colors.gray[100],
+    color: colors.gray[700],
+    border: 'none',
+  };
+};
+
+const getSizeStyles = ($size: ChipSize) => {
+  switch ($size) {
+    case 'small':
+      return {
+        padding: '8px 11px',
+        height: '33px',
+        fontSize: '10px', // 10px
+      };
+    case 'large':
+      return {
+        padding: '12px 14px',
+        height: '35px',
+        font: typography.caption.caption5, //12px
+      };
+    case 'medium':
+    default:
+      return {
+        padding: '8.5px 11px',
+        height: '33px',
+        fontSize: typography.caption.caption5, // 10px
+      };
+  }
+};
+
+export const ChipButton = styled.button<ChipButtonProps>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-weight: 700;
+  line-height: 1.5em;
+
+  ${({ $variant, $isActive }) => {
+    const styles = getChipStyles($variant, $isActive);
+    return `
+      background: ${styles.background};
+      color: ${styles.color};
+      border: ${styles.border};
+    `;
+  }}
+
+  ${({ $size }) => {
+    const sizeStyles = getSizeStyles($size);
+    return `
+      padding: ${sizeStyles.padding};
+      min-height: ${sizeStyles.height};
+      font-size: ${sizeStyles.fontSize};
+    `;
+  }}
+
+  &:hover {
+    opacity: 0.8;
+  }
+`;

--- a/src/components/common/chip/chip.tsx
+++ b/src/components/common/chip/chip.tsx
@@ -1,0 +1,36 @@
+import { CSSProperties } from 'react';
+import { SerializedStyles } from '@emotion/react';
+import { ChipButton, ChipVariant, ChipSize } from './chip.styles';
+
+export interface ChipProps {
+  label: string;
+  variant?: ChipVariant;
+  size?: ChipSize;
+  isActive?: boolean;
+  onClick?: () => void;
+  style?: CSSProperties;
+  css?: SerializedStyles;
+}
+
+export function Chip({
+  label,
+  variant = 'default',
+  size = 'medium',
+  isActive = false,
+  onClick,
+  style,
+  css,
+}: ChipProps) {
+  return (
+    <ChipButton
+      $variant={variant}
+      $size={size}
+      $isActive={isActive}
+      onClick={onClick}
+      style={style}
+      css={css}
+    >
+      {label}
+    </ChipButton>
+  );
+}

--- a/src/components/common/chip/index.ts
+++ b/src/components/common/chip/index.ts
@@ -1,0 +1,4 @@
+export { Chip } from './chip';
+export type { ChipProps } from './chip';
+export type { ChipVariant, ChipSize } from './chip.styles';
+export { ChipButton } from './chip.styles';


### PR DESCRIPTION
### 작업 내용

필터, 검색 등 페이지에서 사용가능한 chip컴포넌트를 구현했습니다.

## 🎨 Variants

### 1. `default`
- **inactive** (`isActive={false}`): 회색 배경, 테두리 없음
- **active** (`isActive={true}`): 초록 배경, 테두리 없음
- **용도**: 상태가 변경되는 기본 필터/탭

### 2. `primary`
- 항상 초록 배경, 테두리 없음 (isActive 무시)
- **용도**: 항상 강조해야 하는 주요 필터

### 3. `outlined`
- 회색 배경 + 테두리 (isActive 무시)
- **용도**: 테두리가 필요한 필터

### 4. `defaultOutlined`
- **inactive** (`isActive={false}`): 회색 배경, 테두리 없음
- **active** (`isActive={true}`): 회색 배경 + 테두리
- **용도**: 선택시 테두리가 생기는 특수한 케이스

## 📏 Sizes

| Size | Height | Padding | Font Size | 용도 |
|------|--------|---------|-----------|------|
| **small** | 33px | 8px 11px | 10px | 필터 칩, 태그 |
| **medium** | 33px | 8.5px 11px | 10px | 기본값 |
| **large** | 35px | 8px 12px | 12px | 탐색 탭 (강조) |


관련이슈 번호를 close해주세요.
close #13
