### PR TITLE
열정기어 tooltip구현 (issue #155)

### DIFF
--- a/src/assets/icons/tootipClose.svg
+++ b/src/assets/icons/tootipClose.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 5L5 15" stroke="#364153" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5 5L15 15" stroke="#364153" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/common/passionMeterTooltip/passionMeterTooltip.styles.ts
+++ b/src/components/common/passionMeterTooltip/passionMeterTooltip.styles.ts
@@ -1,0 +1,79 @@
+import styled from '@emotion/styled';
+import { colors } from '../../../style/colors';
+import { keyframes } from '@emotion/react';
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(-5px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+const fadeOut = keyframes`
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-5px);
+  }
+`;
+
+export const ToastContainer = styled.div<{ isClosing: boolean }>`
+  max-width: 425px;
+  width: 100%;
+  min-height: 56px;
+  padding: 16px 10px;
+  background-color: ${colors.green[100]};
+  border-radius: 6px;
+  box-shadow: 2px 2px 4px 0px rgba(0, 0, 0, 0.05);
+  display: flex;
+  align-items: center;
+  position: absolute;
+  bottom: -70px;
+  gap: 10px;
+  animation: ${({ isClosing }) => (isClosing ? fadeOut : fadeIn)} 0.3s ease-in-out;
+`;
+
+export const ContentWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+`;
+
+export const MessageText = styled.p`
+  font-family: Pretendard;
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 1.5em;
+  letter-spacing: -0.01em;
+  color: ${colors.gray[700]};
+  margin: 0;
+  flex: 1;
+  word-break: keep-all;
+`;
+
+export const CloseButton = styled.button`
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+
+  svg {
+    width: 10px;
+    height: 10px;
+  }
+`;

--- a/src/components/common/passionMeterTooltip/passionMeterTooltip.tsx
+++ b/src/components/common/passionMeterTooltip/passionMeterTooltip.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import * as S from './passionMeterTooltip.styles';
+import close from '../../../assets/icons/tootipClose.svg';
+
+interface PassionMeterTooltipProps {
+  isVisible: boolean;
+  onClose: () => void;
+}
+
+const PassionMeterTooltip = ({ isVisible, onClose }: PassionMeterTooltipProps) => {
+  const [isClosing, setIsClosing] = useState(false);
+
+  useEffect(() => {
+    if (isVisible) {
+      setIsClosing(false);
+
+      const timer = setTimeout(() => {
+        handleClose();
+      }, 3000);
+
+      return () => clearTimeout(timer);
+    }
+  }, [isVisible]);
+
+  const handleClose = () => {
+    setIsClosing(true);
+
+    setTimeout(() => {
+      onClose();
+      setIsClosing(false);
+    }, 300);
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <S.ToastContainer isClosing={isClosing}>
+      <S.ContentWrapper>
+        <S.MessageText>
+          루키의 참여도에 따라 열정이 1~4단계로 높아져요. 프로젝트와 채팅으로 성장해보세요!
+        </S.MessageText>
+        <S.CloseButton onClick={handleClose} aria-label="닫기">
+          <img src={close} alt="close" />
+        </S.CloseButton>
+      </S.ContentWrapper>
+    </S.ToastContainer>
+  );
+};
+
+export default PassionMeterTooltip;

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -48,7 +48,7 @@ const Header = ({ type, title }: HeaderProps) => {
     title: <HeaderTitle>{title}</HeaderTitle>,
     search: (
       <>
-        <Title>검색</Title>
+        <Title>탐색</Title>
         <img
           src={search}
           alt="search"

--- a/src/components/rookieDetail/RookieStats.styles.ts
+++ b/src/components/rookieDetail/RookieStats.styles.ts
@@ -55,6 +55,15 @@ export const PassionMeterContainer = styled.div`
   display: flex;
   align-items: center;
   gap: 2px;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  &:active {
+    opacity: 0.6;
+  }
 `;
 
 export const PassionMeterIcon = styled.div`

--- a/src/components/rookieDetail/RookieStats.tsx
+++ b/src/components/rookieDetail/RookieStats.tsx
@@ -4,6 +4,8 @@ import lv1 from '../../assets/icons/passion/Lv.1.svg';
 import lv2 from '../../assets/icons/passion/Lv.2.svg';
 import lv3 from '../../assets/icons/passion/Lv.3.svg';
 import lv4 from '../../assets/icons/passion/Lv.4.svg';
+import PassionMeterTooltip from '../common/passionMeterTooltip/passionMeterTooltip';
+import { useState } from 'react';
 
 interface RookieStatsProps {
   publicPortfolioCount: string | number;
@@ -12,6 +14,8 @@ interface RookieStatsProps {
 }
 
 function RookieStats({ publicPortfolioCount, responseRate, passionMeter }: RookieStatsProps) {
+  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
+
   // 응답률 포맷팅
   const formatResponseRate = (rate: string | number) => {
     if (typeof rate === 'number') {
@@ -74,13 +78,17 @@ function RookieStats({ publicPortfolioCount, responseRate, passionMeter }: Rooki
                 style={{ width: '100%', height: '100%', objectFit: 'contain' }}
               />
             </S.LevelBadge>
-            <S.PassionMeterContainer>
+            <S.PassionMeterContainer onClick={() => setIsTooltipVisible(true)}>
               <S.PassionMeterText>열정기어</S.PassionMeterText>
-              <img src={passionIcon} alt="열정기여도 정보" />
+              <img src={passionIcon} alt="열정기여도 정보" style={{ cursor: 'pointer' }} />
             </S.PassionMeterContainer>
           </>
         )}
       </S.StatItem>
+      <PassionMeterTooltip
+        isVisible={isTooltipVisible}
+        onClose={() => setIsTooltipVisible(false)}
+      />
     </S.StatsContainer>
   );
 }


### PR DESCRIPTION
### 작업 내용
열정기어 tooltip 구현 
<img width="469" height="202" alt="image" src="https://github.com/user-attachments/assets/ac43dafb-881b-4827-9274-cdd31f4ffd0d" />

- 사용방법
`tooltip`컴포넌트 내부적으로 abosulte가 설정되어 있기에 사용하고자 하는 컨테이너 혹은 wrapper에 `position:relative` 설정해주시면 됩니다.

```typescript
//.tsx 코드
<S.StatsContainer>//사용하고자 하는 컨테이너
      ...중략
      </PassionTooltip>//툴팁
 </S.StatsContainer>
 
//css코드
 export const StatsContainer = styled.div`
  ...중략
  position: relative; // relative설정해야함
`;
```
### 연관 이슈
close #155
